### PR TITLE
se actualiza a la version AutoscalingV2beta2Api

### DIFF
--- a/src/main/java/org/hcjf/io/net/kubernetes/artifacts/KubernetesArtifactResource.java
+++ b/src/main/java/org/hcjf/io/net/kubernetes/artifacts/KubernetesArtifactResource.java
@@ -3,7 +3,7 @@ package org.hcjf.io.net.kubernetes.artifacts;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
-import io.kubernetes.client.openapi.apis.AutoscalingV1Api;
+import io.kubernetes.client.openapi.apis.AutoscalingV2beta2Api;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.util.Yaml;
@@ -34,7 +34,7 @@ public abstract class KubernetesArtifactResource<T extends Object> extends Layer
     private final CoreV1Api coreApi;
     private final AppsV1Api appsApi;
     private final BatchV1Api batchApi;
-    private final AutoscalingV1Api autoscalingApi;
+    private final AutoscalingV2beta2Api autoscalingV2beta2Api;
 
     public KubernetesArtifactResource() {
         try {
@@ -46,7 +46,7 @@ public abstract class KubernetesArtifactResource<T extends Object> extends Layer
         this.coreApi = new CoreV1Api();
         this.appsApi = new AppsV1Api();
         this.batchApi = new BatchV1Api();
-        this.autoscalingApi = new AutoscalingV1Api();
+        this.autoscalingV2beta2Api = new AutoscalingV2beta2Api();
     }
 
     protected abstract Class<T> getArtifactType();
@@ -65,8 +65,8 @@ public abstract class KubernetesArtifactResource<T extends Object> extends Layer
         return batchApi;
     }
 
-    protected final AutoscalingV1Api getAutoscalingApi() {
-        return autoscalingApi;
+    protected final AutoscalingV2beta2Api getAutoscalingV2beta2Api() {
+        return autoscalingV2beta2Api;
     }
 
     protected final ApiClient getClient() {

--- a/src/main/java/org/hcjf/io/net/kubernetes/artifacts/KubernetesHorizontalPodAutoscalerResource.java
+++ b/src/main/java/org/hcjf/io/net/kubernetes/artifacts/KubernetesHorizontalPodAutoscalerResource.java
@@ -1,12 +1,12 @@
 package org.hcjf.io.net.kubernetes.artifacts;
 
-import io.kubernetes.client.openapi.models.V1HorizontalPodAutoscaler;
+import io.kubernetes.client.openapi.models.V2beta2HorizontalPodAutoscaler;
 import org.hcjf.errors.HCJFRuntimeException;
 import org.hcjf.utils.Introspection;
 
 import java.util.Map;
 
-public class KubernetesHorizontalPodAutoscalerResource extends KubernetesArtifactResource<V1HorizontalPodAutoscaler> {
+public class KubernetesHorizontalPodAutoscalerResource extends KubernetesArtifactResource<V2beta2HorizontalPodAutoscaler> {
 
     public static final String NAME = "system_k8s_hpa";
 
@@ -16,18 +16,18 @@ public class KubernetesHorizontalPodAutoscalerResource extends KubernetesArtifac
     }
 
     @Override
-    protected Class<V1HorizontalPodAutoscaler> getArtifactType() {
-        return V1HorizontalPodAutoscaler.class;
+    protected Class<V2beta2HorizontalPodAutoscaler> getArtifactType() {
+        return V2beta2HorizontalPodAutoscaler.class;
     }
 
     @Override
-    protected void createArtifact(V1HorizontalPodAutoscaler artifact, Map<String, Object> rawArtifact) {
+    protected void createArtifact(V2beta2HorizontalPodAutoscaler artifact, Map<String, Object> rawArtifact) {
         try {
             String pretty = Introspection.resolve(rawArtifact, Fields.PRETTY);
             String dryRun = Introspection.resolve(rawArtifact, Fields.DRY_RUN);
             String fieldManager = Introspection.resolve(rawArtifact, Fields.FIELD_MANAGER);
             String fieldValidation = Introspection.resolve(rawArtifact, Fields.FIELD_VALIDATION);
-            getAutoscalingApi().createNamespacedHorizontalPodAutoscaler(getNamespace(), artifact, pretty, dryRun, fieldManager, fieldValidation);
+            getAutoscalingV2beta2Api().createNamespacedHorizontalPodAutoscaler(getNamespace(), artifact, pretty, dryRun, fieldManager, fieldValidation);
         } catch (Exception ex) {
             throw new HCJFRuntimeException("K8s horizontal pod autoscaler creation fail", ex);
         }


### PR DESCRIPTION
Se actualiza la versión V2beta2HorizontalPodAutoscaler en el recurso KubernetesHorizontalPodAutoscalerResource (de Holanda Catalina)  debido a que cuando se intenta generar un nuevo HPA nos encontramos con errores.
https://app.sitrack.io/issueTracker/issue/7fcb4c7d-9f2e-4a42-8a99-06b10dadefa8

