### PR TITLE
#xys1cw423q - LruMap elimina el valor cuando realiza el put del mismo key multiples veces. 

### DIFF
--- a/src/main/java/org/hcjf/utils/LruMap.java
+++ b/src/main/java/org/hcjf/utils/LruMap.java
@@ -117,9 +117,14 @@ public class LruMap<K extends Object, V extends Object> implements Map<K,V> {
     public synchronized V put(K key, V value) {
         V result = mapInstance.put(key, value);
         Key<K> temporalKey = new Key<>(key);
-        keys.add(temporalKey);
-        metadata.put(key, temporalKey);
-        updateMetadata();
+        if (metadata.containsKey(key)) {
+            temporalKey = metadata.get(key);
+            updateMetadata(temporalKey);
+        } else {
+            keys.add(temporalKey);
+            metadata.put(key, temporalKey);
+            updateMetadata();
+        }
         removeOverflow();
         return result;
     }

--- a/src/test/java/org/hcjf/utils/LruMapTest.java
+++ b/src/test/java/org/hcjf/utils/LruMapTest.java
@@ -48,4 +48,29 @@ public class LruMapTest {
         Assert.assertTrue(lruMap.containsKey("3°"));
         Assert.assertTrue(lruMap.containsKey("4°"));
     }
+
+    @Test
+    public void updateKeyOnPutAndRemoveSecond() throws InterruptedException {
+        LruMap<String,String> lruMap = new LruMap<>(3);
+
+        lruMap.put("1°","1°");
+        Thread.sleep(10);
+
+        lruMap.put("2°","2°");
+        Thread.sleep(10);
+
+        lruMap.put("3°","3°");
+        Thread.sleep(10);
+
+        lruMap.put("1°", "1°");
+        Thread.sleep(10);
+
+        lruMap.put("4°","4°");
+        Thread.sleep(10);
+
+        Assert.assertTrue(lruMap.containsKey("1°"));
+        Assert.assertTrue(!lruMap.containsKey("2°"));
+        Assert.assertTrue(lruMap.containsKey("3°"));
+        Assert.assertTrue(lruMap.containsKey("4°"));
+    }
 }


### PR DESCRIPTION
https://issue-tracker.d1rlc0ep0jpfrp.amplifyapp.com/issueTracker/issue/42c36785-766b-4a5e-a134-41b409efc95c