### PR TITLE
Función geoBuffer :: Definir cantidad de segmentos #106

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>com.esri.geometry</groupId>
             <artifactId>esri-geometry-api</artifactId>
-            <version>2.2.4</version>
+            <version>geometry-api-2.2.5-STK</version>
         </dependency>
         <dependency>
             <groupId>org.graalvm.sdk</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -120,9 +120,9 @@
             <version>16.0.0</version>
         </dependency>
         <dependency>
-            <groupId>com.esri.geometry</groupId>
-            <artifactId>esri-geometry-api</artifactId>
-            <version>geometry-api-2.2.5-STK</version>
+            <groupId>io.github.fabian-maysen</groupId>
+            <artifactId>stk-geometry-api</artifactId>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.graalvm.sdk</groupId>

--- a/src/main/java/org/hcjf/layers/query/functions/GeoQueryFunctionLayer.java
+++ b/src/main/java/org/hcjf/layers/query/functions/GeoQueryFunctionLayer.java
@@ -110,8 +110,13 @@ public class GeoQueryFunctionLayer extends BaseQueryFunctionLayer implements Que
             case Functions.GEO_AS_TEXT: result = geometry.asText(); break;
             case Functions.GEO_BOUNDARY: result = geometry.boundary(); break;
             case Functions.GEO_BUFFER: {
-                checkNumberAndType(functionName, parameters, 2, Object.class, Double.class);
-                result = geometry.buffer((Double)parameters[1]);
+                try {
+                    checkNumberAndType(functionName, parameters, 2, Object.class, Double.class);
+                    result = geometry.buffer((Double)parameters[1]);
+                }catch (Exception ex){
+                    checkNumberAndType(functionName, parameters, 3, Object.class, Double.class, Long.class);
+                    result = geometry.buffer((Double)parameters[1], ((Long) parameters[2]).intValue());
+                }
                 break;
             }
             case Functions.GEO_CENTROID: result = geometry.centroid(); break;


### PR DESCRIPTION
Issue #106 

Se modificó la función geoBuffer para tener la opción de definir los puntos, ejemplo de query que devuelve 20 puntos:

**select geoBuffer(geoNew('POINT (-68.780274 -32.878360)'),0.0005,20) as zone from '{}' as data**

También se cambió la versión de geometry-api a la versión que tiene los cambios para definir la cantidad de puntos en el método buffer de OGCGeometry