### PR TITLE
Evaluate de Query,(OrderBy) admite parametros de distintas clases.

### DIFF
--- a/src/main/java/org/hcjf/layers/query/Query.java
+++ b/src/main/java/org/hcjf/layers/query/Query.java
@@ -589,7 +589,6 @@ public class Query extends EvaluatorCollection implements Queryable {
             if (orderParameters.size() > 0) {
                 //If the query has order fields then creates a tree set with
                 //a comparator using the order fields.
-                Object test = new Object();
                 result = new TreeSet<>((o1, o2) -> {
                     int compareResult = 0;
 
@@ -598,10 +597,7 @@ public class Query extends EvaluatorCollection implements Queryable {
                     Class classValueComparable1;
                     Class classValueComparable2;
                     Class defaultClass = null;
-//                    if(!(orderParameters.stream().findFirst().get() instanceof QueryOrderFunction)){
-//QueryOrderParameter parameter = orderParameters.stream().findFirst().get();
-//                                    Comparable<Object> comparableDefaultValue = consumer.get(o1, (QueryParameter) parameter, dataSource);
-//                    }
+
                     for (QueryOrderParameter orderField : orderParameters) {
                         try {
                             if (orderField instanceof QueryOrderFunction) {

--- a/src/main/java/org/hcjf/layers/query/Query.java
+++ b/src/main/java/org/hcjf/layers/query/Query.java
@@ -589,34 +589,61 @@ public class Query extends EvaluatorCollection implements Queryable {
             if (orderParameters.size() > 0) {
                 //If the query has order fields then creates a tree set with
                 //a comparator using the order fields.
+                Object test = new Object();
                 result = new TreeSet<>((o1, o2) -> {
                     int compareResult = 0;
 
                     Comparable<Object> comparable1;
                     Comparable<Object> comparable2;
+                    Class classValueComparable1;
+                    Class classValueComparable2;
+                    Class defaultClass = null;
+//                    if(!(orderParameters.stream().findFirst().get() instanceof QueryOrderFunction)){
+//QueryOrderParameter parameter = orderParameters.stream().findFirst().get();
+//                                    Comparable<Object> comparableDefaultValue = consumer.get(o1, (QueryParameter) parameter, dataSource);
+//                    }
                     for (QueryOrderParameter orderField : orderParameters) {
                         try {
                             if (orderField instanceof QueryOrderFunction) {
-                                comparable1 = consumer.resolveFunction(((QueryOrderFunction) orderField), o1, dataSource);
-                                comparable2 = consumer.resolveFunction(((QueryOrderFunction) orderField), o2, dataSource);
+                                comparable1 = consumer.resolveFunction((QueryOrderFunction) orderField, o1, dataSource);
+                                comparable2 = consumer.resolveFunction((QueryOrderFunction) orderField, o2, dataSource);
                             } else {
                                 comparable1 = consumer.get(o1, (QueryParameter) orderField, dataSource);
                                 comparable2 = consumer.get(o2, (QueryParameter) orderField, dataSource);
+                                classValueComparable1 = comparable1.getClass();
+                                classValueComparable2 = comparable2.getClass();
+
+                                if (!classValueComparable1.equals(classValueComparable2)
+                                        && !(comparable1 instanceof Number && comparable2 instanceof Number)
+                                        && !(comparable1 instanceof Collection || comparable2 instanceof Collection)) {
+                                    String queryString = "SELECT %s from %s";
+                                    Query query = Query.compile(String.format(queryString, orderField.toString(), this.getResource()));
+                                    Queryable queryable = (Queryable) query;
+                                    Collection<?> collectDatasource = dataSource.getResourceData(queryable);
+
+                                    List<Object> defaultList = collectDatasource instanceof ResultSet ?
+                                            new ArrayList<>(Arrays.asList(collectDatasource.toArray())) :
+                                            (List<Object>) collectDatasource;
+
+                                    defaultClass = findDefaultClass(defaultList, orderField.toString());
+                                    comparable1 = transformComparableValues(defaultClass, comparable1);
+                                    comparable2 = transformComparableValues(defaultClass, comparable2);
+                                }
+                            }
+
+                            if (comparable1 == null ^ comparable2 == null) {
+                                compareResult = (comparable1 == null) ? -1 : 1;
+                            } else if (comparable1 == null && comparable2 == null) {
+                                compareResult = 0;
+                            } else {
+                                compareResult = comparable1.compareTo(comparable2) * (orderField.isDesc() ? -1 : 1);
+                            }
+
+                            if (compareResult != 0) {
+                                break;
                             }
                         } catch (ClassCastException ex) {
                             throw new HCJFRuntimeException("Order field must be comparable");
-                        }
-
-                        if (comparable1 == null ^ comparable2 == null) {
-                            compareResult = (comparable1 == null) ? -1 : 1;
-                        } else if (comparable1 == null && comparable2 == null) {
-                            compareResult = 0;
-                        } else {
-                            compareResult = comparable1.compareTo(comparable2) * (orderField.isDesc() ? -1 : 1);
-                        }
-
-                        if (compareResult != 0) {
-                            break;
                         }
                     }
 
@@ -1457,5 +1484,59 @@ public class Query extends EvaluatorCollection implements Queryable {
     public boolean equals(Object obj) {
         return (obj instanceof Query) && obj.toString().equals(toString());
     }
+    /**
+     * This implementation receives the default class from the Datasource and casts the elements to that class.
+     */
+    public Comparable<Object> transformComparableValues(Class typeClass, Comparable<Object> comparable) {
+        Object newValue = null;
+        Comparable<Object> transformComparable;
+        try {
+            String valuesString = comparable.toString();
+            if (typeClass.equals(Integer.class)) {
+                newValue = Integer.valueOf(valuesString);
+            } else if (typeClass.equals(String.class)) {
+                newValue = valuesString;
+            } else if (typeClass.equals(Long.class)) {
+                newValue = Long.valueOf(valuesString);
+            } else if (typeClass.equals(Double.class)) {
+                newValue = Double.valueOf(valuesString);
+            } else if (typeClass.equals(Date.class)) {
+                newValue = new Date(valuesString);
+            } else if (typeClass.equals(Float.class)) {
+                newValue = Float.valueOf(valuesString);
+            }
+            transformComparable = (Comparable<Object>) newValue;
+        } catch (Exception ex) {
+            throw new HCJFRuntimeException("Incompatible data types to compare", ex.getStackTrace());
+        }
+        return transformComparable;
+    }
 
+    /**
+     * This implementation returns the default class of the entered Datasource
+     * @ DataOrigin : List of Object containing Datasource
+     * @ Value : Parameter to search.
+     * @return Returns the class that has the most occurrences in the list.
+     */
+
+    public static Class findDefaultClass (List<Object> dataOrigin, String value) {
+
+        List<Object> data = new ArrayList<>() ;
+        for (Object obj : dataOrigin){
+            Object originValue;
+            if (obj instanceof JoinableMap){
+                originValue = ((JoinableMap) obj).get(value);
+                data.add(originValue);
+            }
+        }
+
+        Map<Class<?>, Long> conteoPorTipo = data.stream()
+                .collect(Collectors.groupingBy(Object::getClass, Collectors.counting()));
+
+        Class defaultClass = conteoPorTipo.entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(null);
+        return defaultClass;
+    }
 }


### PR DESCRIPTION
**https://app.sitrack.io/issueTracker/issue/097dd488-c792-544f-9c89-8637043ab8b9** 

Se modifica el método Evaluate, en Query. Permitiendo que cuando se realiza el ordenamiento en una query y el atributo por el cual se ordena, tiene valores de distintas clases, estos mismos se casteen si es posible permitiendo el ordenamiento.
