### PR TITLE
0044041: Query :: Lentitud En Realizar JOIN

### DIFF
--- a/src/main/java/org/hcjf/layers/query/Query.java
+++ b/src/main/java/org/hcjf/layers/query/Query.java
@@ -1209,40 +1209,95 @@ public class Query extends EvaluatorCollection implements Queryable {
                 break;
             }
         }
-
         Collection<Joinable> result = new ArrayList<>();
         Joinable row;
-        Boolean rowEvaluation;
-        for(Joinable leftJoinable : left) {
-            for(Joinable rightJoinable : right) {
-                row = leftJoinable.join(getResourceName(), join.getResourceName(), rightJoinable);
-                rowEvaluation = false;
+        if (!SystemProperties.getBoolean(SystemProperties.HCJF_JOIN_ONE_EVALUATOR, false)) {
+            Boolean rowEvaluation;
+            for (Joinable leftJoinable : left) {
+                for (Joinable rightJoinable : right) {
+                    row = leftJoinable.join(getResourceName(), join.getResourceName(), rightJoinable);
+                    rowEvaluation = false;
+                    for (Evaluator evaluator : join.getEvaluators()) {
+                        if (!(rowEvaluation = evaluator.evaluate(row, dataSource, consumer))) {
+                            break;
+                        }
+                    }
 
-                for(Evaluator evaluator : join.getEvaluators()) {
-                    if(!(rowEvaluation = evaluator.evaluate(row, dataSource, consumer))) {
-                        break;
+                    if (join.getOuter()) {
+                        rowEvaluation = !rowEvaluation;
+                    }
+
+                    if (rowEvaluation) {
+                        result.add(row);
+                        switch (join.getType()) {
+                            case LEFT: {
+                                leftCopy.remove(leftJoinable);
+                                break;
+                            }
+                            case RIGHT: {
+                                rightCopy.remove(rightJoinable);
+                                break;
+                            }
+                            case FULL: {
+                                leftCopy.remove(leftJoinable);
+                                rightCopy.remove(rightJoinable);
+                                break;
+                            }
+                        }
                     }
                 }
-
-                if(join.getOuter()) {
-                    rowEvaluation = !rowEvaluation;
+            }
+        } else {
+            Equals equals = (Equals) join.getEvaluators().stream().findFirst().get();
+            Map<Object, Collection> rightIndexCollection = new HashMap<>();
+            for (Joinable rightJoinable : right) {
+                Object currentKey;
+                boolean rightJoinableContainsRightValue = ((JoinableMap) rightJoinable).getResources().contains(((QueryField) equals.getRightValue()).getResource().toString());
+                String fieldPath;
+                if (rightJoinableContainsRightValue) {
+                    fieldPath = ((QueryField) equals.getRightValue()).getFieldPath();
+                    currentKey = rightJoinable.get(((QueryField) equals.getRightValue()).getFieldPath());
+                } else {
+                    fieldPath = ((QueryField) equals.getLeftValue()).getFieldPath();
+                    currentKey = rightJoinable.get(((QueryField) equals.getLeftValue()).getFieldPath());
                 }
-
-                if(rowEvaluation) {
-                    result.add(row);
-                    switch (join.getType()) {
-                        case LEFT: {
-                            leftCopy.remove(leftJoinable);
-                            break;
-                        }
-                        case RIGHT: {
-                            rightCopy.remove(rightJoinable);
-                            break;
-                        }
-                        case FULL: {
-                            leftCopy.remove(leftJoinable);
-                            rightCopy.remove(rightJoinable);
-                            break;
+                Collection<Joinable> rightCollection = right.stream().filter(rightMap ->
+                        rightMap.get(fieldPath).equals(currentKey)).collect(Collectors.toList());
+                rightIndexCollection.put(currentKey, rightCollection);
+            }
+            for (Joinable leftJoinable : left) {
+                Object key;
+                boolean leftJoinableContainsRightValue = ((JoinableMap) leftJoinable).getResources().contains(((QueryField) equals.getRightValue()).getResource().toString());
+                if (leftJoinableContainsRightValue) {
+                    key = leftJoinable.get(((QueryField) equals.getRightValue()).getFieldPath());
+                } else {
+                    key = leftJoinable.get(((QueryField) equals.getLeftValue()).getFieldPath());
+                }
+                if (rightIndexCollection.containsKey(key)) {
+                    Collection<Joinable> joinableCollectionById = rightIndexCollection.get(key);
+                    for (Joinable rightJoinable : joinableCollectionById) {
+                        if (rightJoinable != null) {
+                            try {
+                                row = leftJoinable.join(getResourceName(), join.getResourceName(), rightJoinable);
+                                result.add(row);
+                                switch (join.getType()) {
+                                    case LEFT: {
+                                        leftCopy.remove(leftJoinable);
+                                        break;
+                                    }
+                                    case RIGHT: {
+                                        rightCopy.remove(rightJoinable);
+                                        break;
+                                    }
+                                    case FULL: {
+                                        leftCopy.remove(leftJoinable);
+                                        rightCopy.remove(rightJoinable);
+                                        break;
+                                    }
+                                }
+                            } catch (Exception ex) {
+                                throw new HCJFRuntimeException("Error in join: ", ex.getMessage());
+                            }
                         }
                     }
                 }
@@ -1264,7 +1319,6 @@ public class Query extends EvaluatorCollection implements Queryable {
                 break;
             }
         }
-
         return result;
     }
 

--- a/src/main/java/org/hcjf/properties/SystemProperties.java
+++ b/src/main/java/org/hcjf/properties/SystemProperties.java
@@ -40,6 +40,7 @@ public final class SystemProperties extends Properties {
     public static final String HCJF_DEFAULT_LRU_MAP_SIZE = "hcjf.default.lru.map.size";
     public static final String HCJF_DEFAULT_EXCEPTION_MESSAGE_TAG = "hcjf.default.exception.message.tag";
     public static final String HCJF_CHECKSUM_ALGORITHM = "hcjf.checksum.algorithm";
+    public static final String HCJF_JOIN_ONE_EVALUATOR = "hcjf.query.join.one.evaluator";
 
     public static final class Locale {
         public static final String LOG_TAG = "hcjf.locale.log.tag";


### PR DESCRIPTION
Las queries con joins se demoran en los bucles anidados de right y left. 

Si la property HCJF_JOIN_ONE_EVALUATOR es false, se utilizará el código de antes para los joins, si es true se usará el nuevo código en el cual se crea un mapa de colecciones("right"), usando el "id" como key, y el valor serán los resultados que tengan ese id, luego, en el bucle left se buscarán las coincidencias del join buscando por ese id.

https://mantis.sitrack.com/view.php?id=44041